### PR TITLE
Fix ElasticSearch field search and cleanup startup

### DIFF
--- a/src/corePackages/Core.ElasticSearch/ElasticSearchManager.cs
+++ b/src/corePackages/Core.ElasticSearch/ElasticSearchManager.cs
@@ -103,7 +103,11 @@ public class ElasticSearchManager : IElasticSearch
         ISearchResponse<T>? searchResponse = await elasticClient.SearchAsync<T>(s => s
                                                  .Index(fieldParameters.IndexName)
                                                  .From(fieldParameters.From)
-                                                 .Size(fieldParameters.Size));
+                                                 .Size(fieldParameters.Size)
+                                                 .Query(q => q
+                                                     .Match(m => m
+                                                         .Field(fieldParameters.FieldName)
+                                                         .Query(fieldParameters.Value))));
 
         List<ElasticSearchGetModel<T>> list = searchResponse.Hits.Select(x => new ElasticSearchGetModel<T>
         {

--- a/src/demoProjects/templateProject/WebAPI/Program.cs
+++ b/src/demoProjects/templateProject/WebAPI/Program.cs
@@ -15,10 +15,6 @@ builder.Services.AddSecurityServices();
 builder.Services.AddPersistenceServices(builder.Configuration);
 builder.Services.AddInfrastructureServices();
 builder.Services.AddHttpContextAccessor();
-
-
-
-builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();


### PR DESCRIPTION
## Summary
- fix SearchByField to query by specified field
- remove duplicate `AddControllers` call in startup

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872048eca3083249928f82b626cfd14