### PR TITLE
Fix template feature mappings and validation

### DIFF
--- a/src/demoProjects/templateProject/Application/Features/someFeature/Commands/CreateSomeFeature/CreateSomeFeatureEntityCommandValidator.cs
+++ b/src/demoProjects/templateProject/Application/Features/someFeature/Commands/CreateSomeFeature/CreateSomeFeatureEntityCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Application.Features.someFeature.Commands.CreateSomeFeature
+{
+    public class CreateSomeFeatureEntityCommandValidator : AbstractValidator<CreateSomeFeatureEntityCommand>
+    {
+        public CreateSomeFeatureEntityCommandValidator()
+        {
+            RuleFor(c => c.Name).NotEmpty();
+        }
+    }
+}

--- a/src/demoProjects/templateProject/Application/Features/someFeature/Profiles/MappingProfiles.cs
+++ b/src/demoProjects/templateProject/Application/Features/someFeature/Profiles/MappingProfiles.cs
@@ -1,9 +1,7 @@
-﻿using AutoMapper;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using AutoMapper;
+using Application.Features.someFeature.Dtos;
+using Application.Features.someFeature.Commands.CreateSomeFeature;
+using Domain.Entities;
 
 namespace Application.Features.someFeature.Profiles
 {
@@ -11,6 +9,8 @@ namespace Application.Features.someFeature.Profiles
     {
         public MappingProfiles()
         {
+            CreateMap<SomeFeatureEntity, CreatedSomeFeatureEntityDto>().ReverseMap();
+            CreateMap<SomeFeatureEntity, CreateSomeFeatureEntityCommand>().ReverseMap();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add validation rules for `CreateSomeFeatureEntityCommand`
- configure object mappings for SomeFeature DTOs and commands

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687204f268e48324bae4304a9b3f1bff